### PR TITLE
Added collapsed class option to text

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ new Vue({
 <truncate clamp="..." :length="90" less="Show Less" type="html" text="<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p> <p> Quam modi consequuntur quis porro explicabo iusto repudiandae odio nobis, assumenda iure totam, eum expedita quae at nostrum excepturi corrupti unde et.</p>"></truncate>
 ```
 
+#### Add class to collapsed text
+
+```html
+<truncate collapsed-text-class="collapsed" clamp="Show more" :length="90" less="Show Less" type="html" text="<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p> <p> Quam modi consequuntur quis porro explicabo iusto repudiandae odio nobis, assumenda iure totam, eum expedita quae at nostrum excepturi corrupti unde et.</p>"></truncate>
+```
+
 ## Attributes
 
 
@@ -65,7 +71,7 @@ new Vue({
 | __clamp__    | Read More | string | Link that will be after the text with a link to expand. |
 | __less__   | Show Less | string | Link that will be after the text when it's expand, when click text collapses. |
 | __type__   | text | string | Either `text` or `html`. To change whether to treat the input from `text` attribute as text or raw HTML. |
-| __class__   | empty string | string | To add a class name to the link that will be after the text is expanded or collapsed. |
+| __collapsedTextClass__   | '' | string | Allows you to add a class to the text when it is collapsed. |
 
 ## License
 

--- a/truncate.vue
+++ b/truncate.vue
@@ -1,18 +1,20 @@
 <template>
   <div>
-    <p v-if="!show">
-      {{truncate(text)}} 
-      <a v-if="text.length >= length" @click="toggle()" :class="actionClass">{{clamp || 'Read More'}}</a>
-    </p>
-    <p v-if="show && type !== 'html'">
-      {{text}} 
-      <a @click="toggle()" v-if="text.length >= length" :class="actionClass">{{less || 'Show Less'}}</a>
-    </p>
+    <div v-if="!show">
+      <span :class="textClass">
+        {{truncate(text)}}
+      </span>
+      <a v-if="text.length >= length" @click="toggle()">{{clamp || 'Read More'}}</a>
+    </div>
+    <div v-if="show && type !== 'html'">
+      <span>{{text}}</span>
+      <a @click="toggle()" v-if="text.length >= length">{{less || 'Show Less'}}</a>
+    </div>
     <div v-else-if="show && type === 'html'">
       <div v-html="text"  v-if="text.length >= length"></div>
-      <a @click="toggle()" v-if="text.length >= length" :class="actionClass">{{less || 'Show Less'}}</a>
+      <a @click="toggle()" v-if="text.length >= length">{{less || 'Show Less'}}</a>
       <p v-else>
-        {{h2p(text)}} 
+        {{h2p(text)}}
       </p>
     </div>
   </div>
@@ -22,9 +24,12 @@
 var h2p = require('html2plaintext')
 
 export default {
-
   name: 'truncate',
   props: {
+    collapsedTextClass: {
+        type: String,
+        required: false
+    },
     text: String,
     clamp: String,
     length: Number,
@@ -32,10 +37,11 @@ export default {
     type: {
       type: String,
       default: 'text'
-    },
-    actionClass: {
-      type: String,
-      default: ''
+    }
+  },
+  computed: {
+    textClass () {
+      return (this.text.length > this.length && this.collapsedTextClass) ? this.collapsedTextClass : '';
     }
   },
   methods: {


### PR DESCRIPTION
Use case for this feature is:

- Display ellipsis at the end of the text when text.length > length through a css class while rendering a "Show more" (clamp) button at the same time