### PR TITLE
FEATURE property to control truncation state

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ new Vue({
 
 | Option        | Default       | Type   | Description  |
 | :------------ | :------------ | :----- | :--------- |
+| __truncated__ | false | boolean | The initial state of the truncation. `true` is collapsed, `false` is expanded. |
 | __text__     | no default value | string | The text that will be truncated. |
 | __length__   | 100 | number | Length of text after truncate. |
 | __clamp__    | Read More | string | Link that will be after the text with a link to expand. |

--- a/src/truncate.vue
+++ b/src/truncate.vue
@@ -47,6 +47,10 @@ export default {
   name: 'Truncate',
 
   props: {
+    truncated: {
+      type: Boolean,
+      default: true
+    },
     collapsedTextClass: {
       type: String,
       default: '',
@@ -76,6 +80,10 @@ export default {
       default: '',
     },
   },
+  created() {
+    this.show = this.truncated
+    this.toggle(this.truncated)
+  },
   data() {
     return {
       show: false,
@@ -97,8 +105,9 @@ export default {
 
       return '';
     },
-    toggle() {
-      const toggled = !this.show;
+    toggle(override) {
+      // use the override value if it is set as a boolean
+      const toggled = typeof override === 'boolean' ? override : !this.show;
 
       this.show = toggled;
       this.$emit('toggle', toggled);
@@ -107,6 +116,11 @@ export default {
     h2p(text) {
       return h2p(text);
     },
+  },
+  watch: {
+    truncated(value) {
+      this.toggle(value)
+    }
   },
 };
 </script>


### PR DESCRIPTION
This allows the truncation to be expanded or collapsed via a property.

Contracted:

    <truncate :truncated="true">...</truncate>

Expanded:

    <truncate :truncated="false">...</truncate>

Bound:

    <truncate :truncated="isExpanded">...</truncate>

    data() {
      isExpanded: true
    }

**NOTE: I'm unsure if the property should be named to something truthy by default, like `expanded` so that `true` is expanded and `false` is collapsed**