### PR TITLE
Fix truncation length calculation when comparing html input to max chars allowed

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   ],
   "scripts": {
     "build:plugin": "webpack --config ./webpack.plugin.config.js  --progress --hide-modules",
-    "build": "rm -rf ./dist && bili && npm run build:plugin"
+    "build": "rm -rf ./dist && bili && npm run build:plugin",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/src/truncate.vue
+++ b/src/truncate.vue
@@ -4,35 +4,35 @@
       <span :class="textClass">
         {{ truncate(text) }}
       </span>
-      <a
+      <button
         v-if="showToggle && text.length >= length"
         :class="actionClass"
-        @click="toggle()">{{ clamp }}</a>
+        @click="toggle">{{ clamp }}</button>
     </div>
     <div v-else-if="!show && isHTML">
       <span
         :class="textClass"
         v-html="truncate(text)" />
-      <a
+      <button
         v-if="showToggle && text.length >= length"
         :class="actionClass"
-        @click="toggle()">{{ clamp }}</a>
+        @click="toggle">{{ clamp }}</button>
     </div>
     <div v-if="show && !isHTML">
       <span>{{ text }}</span>
-      <a
+      <button
         v-if="showToggle && text.length >= length"
         :class="actionClass"
-        @click="toggle()">{{ less }}</a>
+        @click="toggle">{{ less }}</button>
     </div>
     <div v-else-if="show && isHTML">
       <div
         v-if="text.length >= length"
         v-html="text" />
-      <a
+      <button
         v-if="showToggle && text.length >= length"
         :class="actionClass"
-        @click="toggle()">{{ less }}</a>
+        @click="toggle">{{ less }}</button>
       <p v-else>
         {{ h2p(text) }}
       </p>
@@ -119,9 +119,3 @@ export default {
   },
 };
 </script>
-
-<style lang="css" scoped>
-  a {
-    cursor: pointer;
-  }
-</style>

--- a/src/truncate.vue
+++ b/src/truncate.vue
@@ -90,7 +90,9 @@ export default {
     },
     textLength() {
       if (this.isHTML) {
-        const text = h2p(this.text, 0);
+        // We need the length of the text without the html being considered
+        // This ensures we provide the right calculation for when to show/hide the more link
+        const text = this.text.replace(/<[^>]*>/g, '');
         return text.length;
       }
 

--- a/src/truncate.vue
+++ b/src/truncate.vue
@@ -84,18 +84,18 @@ export default {
   },
   computed: {
     isHTML() {
-        return type === 'html';
+      return this.type === 'html';
     },
     textClass() {
       return (this.textLength > this.length && this.collapsedTextClass) ? this.collapsedTextClass : '';
     },
     textLength() {
-        if (this.isHTML) {
-            const text = h2p(this.text, 0);
-            return text.length;
-        }
+      if (this.isHTML) {
+        const text = h2p(this.text, 0);
+        return text.length;
+      }
 
-        return this.text.length;
+      return this.text.length;
     },
   },
   methods: {

--- a/src/truncate.vue
+++ b/src/truncate.vue
@@ -5,7 +5,7 @@
         {{ truncate(text) }}
       </span>
       <a
-        v-if="text.length >= length"
+        v-if="showToggle && text.length >= length"
         :class="actionClass"
         @click="toggle()">{{ clamp }}</a>
     </div>
@@ -14,14 +14,14 @@
         :class="textClass"
         v-html="truncate(text)" />
       <a
-        v-if="text.length >= length"
+        v-if="showToggle && text.length >= length"
         :class="actionClass"
         @click="toggle()">{{ clamp }}</a>
     </div>
     <div v-if="show && !isHTML">
       <span>{{ text }}</span>
       <a
-        v-if="text.length >= length"
+        v-if="showToggle && text.length >= length"
         :class="actionClass"
         @click="toggle()">{{ less }}</a>
     </div>
@@ -30,7 +30,7 @@
         v-if="text.length >= length"
         v-html="text" />
       <a
-        v-if="text.length >= length"
+        v-if="showToggle && text.length >= length"
         :class="actionClass"
         @click="toggle()">{{ less }}</a>
       <p v-else>
@@ -79,7 +79,6 @@ export default {
   data() {
     return {
       show: false,
-      counter: this.length,
     };
   },
   computed: {
@@ -96,6 +95,9 @@ export default {
       }
 
       return this.text.length;
+    },
+    showToggle() {
+      return this.textLength > this.length;
     },
   },
   methods: {

--- a/src/truncate.vue
+++ b/src/truncate.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div v-if="!show && type !== 'html'">
+    <div v-if="!show && !isHTML">
       <span :class="textClass">
         {{ truncate(text) }}
       </span>
@@ -9,7 +9,7 @@
         :class="actionClass"
         @click="toggle()">{{ clamp }}</a>
     </div>
-    <div v-else-if="!show && type === 'html'">
+    <div v-else-if="!show && isHTML">
       <span
         :class="textClass"
         v-html="truncate(text)" />
@@ -18,14 +18,14 @@
         :class="actionClass"
         @click="toggle()">{{ clamp }}</a>
     </div>
-    <div v-if="show && type !== 'html'">
+    <div v-if="show && !isHTML">
       <span>{{ text }}</span>
       <a
         v-if="text.length >= length"
         :class="actionClass"
         @click="toggle()">{{ less }}</a>
     </div>
-    <div v-else-if="show && type === 'html'">
+    <div v-else-if="show && isHTML">
       <div
         v-if="text.length >= length"
         v-html="text" />
@@ -83,8 +83,19 @@ export default {
     };
   },
   computed: {
+    isHTML() {
+        return type === 'html';
+    },
     textClass() {
-      return (this.text.length > this.length && this.collapsedTextClass) ? this.collapsedTextClass : '';
+      return (this.textLength > this.length && this.collapsedTextClass) ? this.collapsedTextClass : '';
+    },
+    textLength() {
+        if (this.isHTML) {
+            const text = h2p(this.text, 0);
+            return text.length;
+        }
+
+        return this.text.length;
     },
   },
   methods: {
@@ -102,10 +113,6 @@ export default {
 
       this.show = toggled;
       this.$emit('toggle', toggled);
-    },
-
-    h2p(text) {
-      return h2p(text);
     },
   },
 };


### PR DESCRIPTION
This fixes an issue with the truncation length reported when using html input. This will fix the issue called out in https://github.com/kavalcante/vue-truncate-collapsed/issues/16.

Couple of things to note:
* Added `prepare` script to `package.json` to support installing the package from GitHub
* Converted `<a>` tags to `<button>`s for accessibility purposes
* Added a `showToggle` prop to completely hide the buttons when the input length does not exceed the max length

Let me know if you have any questions 👋 